### PR TITLE
Add glhf.chat to bolt.diy

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -297,7 +297,15 @@ export const ChatImpl = memo(
         });
 
         if (template !== 'blank') {
-          const temResp = await getTemplates(template, title);
+          const temResp = await getTemplates(template, title).catch((e) => {
+            if (e.message.includes('rate limit')) {
+              toast.warning('Rate limit exceeded. Skipping starter template\n Continuing with blank template');
+            } else {
+              toast.warning('Failed to import starter template\n Continuing with blank template');
+            }
+
+            return null;
+          });
 
           if (temResp) {
             const { assistantMessage, userMessage } = temResp;

--- a/app/lib/modules/llm/providers/hyperbolic.ts
+++ b/app/lib/modules/llm/providers/hyperbolic.ts
@@ -6,7 +6,7 @@ import { createOpenAI } from '@ai-sdk/openai';
 
 export default class HyperbolicProvider extends BaseProvider {
   name = 'Hyperbolic';
-  getApiKeyLink = 'https://hyperbolic.xyz/settings';
+  getApiKeyLink = 'https://app.hyperbolic.xyz/settings';
 
   config = {
     apiTokenKey: 'HYPERBOLIC_API_KEY',


### PR DESCRIPTION
I added the open model execution service, all tests have already been carried out.
Some models were selected but others may be added later.

What was done:
The service provider has been added to the directory:

bolt.diy\app\lib\modules\llm\providers\glhf.chat.ts

The new service provider configuration was added to the file:

bolt.diy\app\lib\modules\llm\registry.ts

The API settings and access link were added to the file:

bolt.diy.env.example